### PR TITLE
Fix axis usage in zoomOut method

### DIFF
--- a/packages/easy_onvif/lib/src/ptz.dart
+++ b/packages/easy_onvif/lib/src/ptz.dart
@@ -668,7 +668,7 @@ class Ptz extends Operation {
   Future<void> zoomOut(String profileToken, [double step = 0.025]) async {
     loggy.debug('zoomOut');
 
-    await zoom(profileToken, Vector1D(x: step));
+    await zoom(profileToken, Vector1D(x: -step));
   }
 
   void _clearDefaults() {


### PR DESCRIPTION
#### Description:
This PR fixes the axis usage in the `zoomOut` method to align with their intended behavior as described in the comments.

---

#### Changes Made:
1. Updated `zoomOut` to manipulate the **negative z-axis** (farther).

---

#### Updated Code:
```dart
  /// A helper method to perform a single [step] of a [relativeMove] on the
  /// negative y axis (farther)
  Future<void> zoomOut(String profileToken, [double step = 0.025]) async {
    loggy.debug('zoomOut');

    await zoom(profileToken, Vector1D(x: -step));
  }
```

---

#### Testing:
- Verified `zoomIn` moves closer along the positive z-axis.
- Verified `zoomOut` moves farther along the negative z-axis.

---

#### Related Issue:
Fixes #63 